### PR TITLE
Get Swagger in Linux, don't insist on Selenium

### DIFF
--- a/scripts/generate_api_cache.py
+++ b/scripts/generate_api_cache.py
@@ -94,6 +94,16 @@ def install_tools():
 
         print('Test the generator installation by invoking its help screen.')
         os.system('/usr/local/bin/swagger-codegen -h')
+    elif platform == 'linux':  # Linux platform
+        # Don't install packages without user interaction.
+        if not os.path.isfile('swagger-codegen-cli.jar'):
+            os.system(
+                'wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/'
+                + 'swagger-codegen-cli/3.0.26/swagger-codegen-cli-3.0.26.jar '
+                + '-O swagger-codegen-cli.jar'
+            )
+        print('Test the generator installation by invoking its help screen.')
+        os.system('java -jar swagger-codegen-cli.jar -h')
     else:
         assert False, f'Please extend install_tools() for your {platform} platform.'
 
@@ -128,6 +138,9 @@ def main():
         name = f'{category}_{call}'
         if platform == 'darwin':  # OS X or MacOS
             command = f'/usr/local/bin/swagger-codegen generate -l python ' \
+                      f'-o {TARGET_PATH}/{name} -DpackageName={name} -i {url} '
+        elif platform == 'linux':  # Linux
+            command = f'java -jar swagger-codegen-cli.jar generate -l python ' \
                       f'-o {TARGET_PATH}/{name} -DpackageName={name} -i {url} '
         else:
             assert False, f'Please extend main() for your {platform} platform.'

--- a/src/ebay_rest/token.py
+++ b/src/ebay_rest/token.py
@@ -6,10 +6,6 @@ import time
 import threading
 from urllib.parse import parse_qs
 
-# Third party imports
-from selenium import webdriver  # match webdriver & chrome version https://sites.google.com/chromium.org/driver/
-# on Mac, in a terminal, brew install chromedriver
-
 # Local imports
 from .date_time import DateTime
 from .error import Error
@@ -225,7 +221,9 @@ class Token:
         delay = 5  # delay seconds to give the page an opportunity to render
 
         # open browser and load the initial page
-        browser = webdriver.Chrome()
+        import selenium  # match webdriver & chrome version https://sites.google.com/chromium.org/driver/
+        # on Mac, in a terminal, brew install chromedriver
+        browser = selenium.webdriver.Chrome()
         browser.get(sign_in_url)
         time.sleep(delay)
 


### PR DESCRIPTION
Two small changes to make the scripts work on Linux and stop it failing on my system due to a (mostly unnecessary) dependency on Selenium.

On Linux, where it is not as trivial to install swagger-codegen through a package manager, directly download the jar to the current working directory and run from there.

In tokens.py, make selenium a just-in-time import. If you can't do the authorization flow, but are able to supply a refresh token (I have this working with some hackery involving patching out _refresh_user but should probably be made easier), Selenium is unnecessary.