### PR TITLE
Api and token fixes/improvements

### DIFF
--- a/src/ebay_rest/a_p_i.py
+++ b/src/ebay_rest/a_p_i.py
@@ -235,6 +235,8 @@ class API:
         :param function_client:
         :param method:
         :param object_error:
+        :param user_access_token:
+        :param rate_keys:
         :param params:
         :param kwargs:
         :return:
@@ -263,7 +265,7 @@ class API:
 
         Across all pages, eBay has a hard limit on how many records it will return. This is subject to change
         and can vary by call. The swagger call will raise an exception at the limit. 10,000 is a common hard limit.
-        
+
         :param function_configuration:
         :param base_path:
         :param function_instance:
@@ -364,8 +366,8 @@ class API:
 
         # Configure the host endpoint
         if self._sandbox:
-            configuration.host = configuration.host.replace('api.ebay.com',
-                                                            'api.sandbox.ebay.com')
+            configuration.host = configuration.host.replace('.ebay.com',
+                                                            '.sandbox.ebay.com')
         # check for host has flaws and then then compensate
         if '{basePath}' in configuration.host:
             configuration.host = configuration.host.replace('{basePath}', base_path)
@@ -387,7 +389,7 @@ class API:
         # https://developer.ebay.com/api-docs/buy/static/ref-marketplace-supported.html
         marketplace_id = self._marketplace_id
         if user_access_token:
-            for param in params:
+            for param in (params or []):
                 if param in self._marketplace_ids:
                     marketplace_id = param
         # if '/buy/offer' in base_path:

--- a/src/ebay_rest/a_p_i.py
+++ b/src/ebay_rest/a_p_i.py
@@ -74,6 +74,7 @@ class API:
     """
     _get_swagger_call_limits = None
     _instances = []
+    _Token = Token  # Link to Token class
 
     def __init__(self, sandbox: bool = False, marketplace_id: str = 'EBAY_US',
                  country_code: str = None, zip_code: str = None,
@@ -193,7 +194,7 @@ class API:
 
                     # get a token, so that any credential problem will be discovered ASAP
                     try:
-                        Token.get_application(sandbox=sandbox)
+                        self._Token.get_application(sandbox=sandbox)
                     except Error as error:
                         number = error.number
                         reason = error.reason
@@ -209,6 +210,11 @@ class API:
 
         logging.debug("An instance that __new__ created should always be found!")   # abnormal fail
         return
+
+    @classmethod
+    def set_credentials(cls, *args, **kwargs):
+        """Wrapper for Token._set_credentials."""
+        return cls._Token._set_credentials(*args, **kwargs)
 
     def __new__(cls, *args, **kwargs):
         """ When init parameters match, conserve resources, reuse an old initialized object instead of making a new.
@@ -358,9 +364,9 @@ class API:
         configuration = function_configuration()
         try:
             if user_access_token:
-                configuration.access_token = Token.get_user(sandbox=self._sandbox)
+                configuration.access_token = self._Token.get_user(sandbox=self._sandbox)
             else:
-                configuration.access_token = Token.get_application(sandbox=self._sandbox)
+                configuration.access_token = self._Token.get_application(sandbox=self._sandbox)
         except Error:
             raise
 

--- a/src/ebay_rest/token.py
+++ b/src/ebay_rest/token.py
@@ -30,9 +30,9 @@ class Token:
     _user_scopes = dict()
     _allow_get_user_consent = True
 
-    @staticmethod
+    @classmethod
     def _set_credentials(
-            sandbox: bool, app_id, cert_id,
+            cls, sandbox: bool, app_id, cert_id,
             dev_id, ru_name=None, scopes=None,
             refresh_token=None, refresh_token_expiry=None,
             allow_get_user_consent=True):
@@ -55,23 +55,23 @@ class Token:
         # Create Credentials for sandbox/production
         app_info = Credentials(app_id, cert_id, dev_id, ru_name)
         # Set up Token
-        with Token._lock:
+        with cls._lock:
             CredentialUtil._credential_list.update({env.config_id: app_info})
-            Token._oauth2api_inst = OAuth2Api()
+            cls._oauth2api_inst = OAuth2Api()
             if scopes:
-                Token._user_scopes[sandbox] = scopes
+                cls._user_scopes[sandbox] = scopes
             if refresh_token:
                 if not refresh_token_expiry:
                     raise ValueError(
                         'Must supply refresh token expiry with refresh token!')
-                Token._token_refresh_user[sandbox] = OAuthToken(
+                cls._token_refresh_user[sandbox] = OAuthToken(
                     refresh_token=refresh_token,
                     refresh_token_expiry=refresh_token_expiry
                 )
-            Token._allow_get_user_consent = allow_get_user_consent
+            cls._allow_get_user_consent = allow_get_user_consent
 
-    @staticmethod
-    def get_application(sandbox: bool):
+    @classmethod
+    def get_application(cls, sandbox: bool):
         """
         Get an eBay Application Token.
 
@@ -81,25 +81,25 @@ class Token:
         sandbox (bool): {True, False} For the sandbox True, for production False.
         """
 
-        with Token._lock:
-            Token._instantiate()
+        with cls._lock:
+            cls._instantiate()
 
-            if sandbox not in Token._application_scopes:
-                Token._determine_application_scopes(sandbox)
+            if sandbox not in cls._application_scopes:
+                cls._determine_application_scopes(sandbox)
 
-            if sandbox not in Token._token_application:
-                Token._refresh_application(sandbox)
+            if sandbox not in cls._token_application:
+                cls._refresh_application(sandbox)
 
-            if (Token._token_application[sandbox].token_expiry
+            if (cls._token_application[sandbox].token_expiry
                     .replace(tzinfo=timezone.utc) <= DateTime.now()):
-                Token._refresh_application(sandbox)
+                cls._refresh_application(sandbox)
 
-            token = Token._token_application[sandbox].access_token
+            token = cls._token_application[sandbox].access_token
 
         return token
 
-    @staticmethod
-    def _determine_application_scopes(sandbox: bool):
+    @classmethod
+    def _determine_application_scopes(cls, sandbox: bool):
         """
         Determine the application scopes that are currently allowed.
 
@@ -113,17 +113,17 @@ class Token:
             env = Environment.PRODUCTION
             scopes = []
             for scope in Reference.get_application_scopes():
-                token_application = Token._oauth2api_inst.get_application_token(
+                token_application = cls._oauth2api_inst.get_application_token(
                     env, [scope])
                 if token_application.error is None:
                     if token_application.access_token is not None:
                         if len(token_application.access_token) > 0:
                             scopes.append(scope)
 
-        Token._application_scopes[sandbox] = scopes
+        cls._application_scopes[sandbox] = scopes
 
-    @staticmethod
-    def _refresh_application(sandbox: bool):
+    @classmethod
+    def _refresh_application(cls, sandbox: bool):
         """
         Refresh the eBay Application Token and update all that comes with it.
 
@@ -137,19 +137,19 @@ class Token:
             env = Environment.PRODUCTION
 
         # Get the list of scopes which resemble urls.
-        scopes = Token._application_scopes[sandbox]
+        scopes = cls._application_scopes[sandbox]
 
-        token_application = Token._oauth2api_inst.get_application_token(env, scopes)
+        token_application = cls._oauth2api_inst.get_application_token(env, scopes)
         if token_application.error is not None:
             reason = 'token_application.error ' + token_application.error
             raise Error(number=1, reason=reason)
         if (token_application.access_token is None) or (len(token_application.access_token) == 0):
             raise Error(number=1, reason='token_application.access_token is missing.')
 
-        Token._token_application[sandbox] = token_application
+        cls._token_application[sandbox] = token_application
 
-    @staticmethod
-    def get_user(sandbox: bool):
+    @classmethod
+    def get_user(cls, sandbox: bool):
         """
         Get an eBay User Access Token.
 
@@ -159,25 +159,25 @@ class Token:
         sandbox (bool): {True, False} For the sandbox True, for production False.
         """
 
-        with Token._lock:
-            Token._instantiate()
+        with cls._lock:
+            cls._instantiate()
 
-            if sandbox not in Token._user_scopes:
-                Token._determine_user_scopes(sandbox)
+            if sandbox not in cls._user_scopes:
+                cls._determine_user_scopes(sandbox)
 
-            if sandbox not in Token._token_user:
-                Token._refresh_user(sandbox)
+            if sandbox not in cls._token_user:
+                cls._refresh_user(sandbox)
 
-            if (Token._token_user[sandbox].token_expiry
+            if (cls._token_user[sandbox].token_expiry
                     .replace(tzinfo=timezone.utc) <= DateTime.now()):
-                Token._refresh_user(sandbox)
+                cls._refresh_user(sandbox)
 
-            token = Token._token_user[sandbox].access_token
+            token = cls._token_user[sandbox].access_token
 
         return token
 
-    @staticmethod
-    def _determine_user_scopes(sandbox: bool):
+    @classmethod
+    def _determine_user_scopes(cls, sandbox: bool):
         """
         Determine the user access scopes that are currently allowed.
 
@@ -194,10 +194,10 @@ class Token:
                       "https://api.ebay.com/oauth/api_scope/sell.account",
                       "https://api.ebay.com/oauth/api_scope/sell.fulfillment"]
 
-        Token._user_scopes[sandbox] = scopes
+        cls._user_scopes[sandbox] = scopes
 
-    @staticmethod
-    def _refresh_user(sandbox: bool):
+    @classmethod
+    def _refresh_user(cls, sandbox: bool):
         """
         Refresh the eBay User Access Token and update all that comes with it.
         If we don't have a current refresh token, run the authorization flow.
@@ -206,22 +206,22 @@ class Token:
         sandbox (bool): {True, False} For the sandbox True, for production False.
         """
 
-        if sandbox not in Token._token_refresh_user:
+        if sandbox not in cls._token_refresh_user:
             # We don't have a refresh token; run authorization flow
-            Token._authorization_flow(sandbox)
+            cls._authorization_flow(sandbox)
 
-        elif (Token._token_refresh_user[sandbox].refresh_token_expiry
+        elif (cls._token_refresh_user[sandbox].refresh_token_expiry
                 .replace(tzinfo=timezone.utc) <= DateTime.now()):
             # The refresh token has expired; run authorization flow
-            Token._authorization_flow(sandbox)
+            cls._authorization_flow(sandbox)
 
         else:
             # Exchange our still current refresh token for a
             # new user access token
-            Token._refresh_user_token(sandbox)
+            cls._refresh_user_token(sandbox)
 
-    @staticmethod
-    def _authorization_flow(sandbox: bool):
+    @classmethod
+    def _authorization_flow(cls, sandbox: bool):
         """Get an authorization code by running the authorization_flow, and
         then exchange that for a refresh token (which also contains a
         user token).
@@ -230,24 +230,24 @@ class Token:
         sandbox (bool): {True, False} For the sandbox True, for production False.
         """
 
-        if not Token._allow_get_user_consent:
+        if not cls._allow_get_user_consent:
             raise RuntimeError('Getting user consent via browser disabled')
 
         # Get the list of scopes which resemble urls.
-        scopes = Token._user_scopes[sandbox]
+        scopes = cls._user_scopes[sandbox]
 
         if sandbox:
             env = Environment.SANDBOX
         else:
             env = Environment.PRODUCTION
 
-        sign_in_url = Token._oauth2api_inst.generate_user_authorization_url(env, scopes)
+        sign_in_url = cls._oauth2api_inst.generate_user_authorization_url(env, scopes)
         if sign_in_url is None:
             raise Error(number=1, reason='sign_in_url is None.')
 
-        code = Token._get_authorization_code(sign_in_url)
+        code = cls._get_authorization_code(sign_in_url)
 
-        refresh_token = Token._oauth2api_inst.exchange_code_for_access_token(env, code)
+        refresh_token = cls._oauth2api_inst.exchange_code_for_access_token(env, code)
 
         if refresh_token.access_token is None:
             raise Error(number=1, reason='refresh_token.access_token is None.')
@@ -255,30 +255,30 @@ class Token:
             raise Error(number=1, reason='refresh_token.access_token is of length zero.')
 
         # Split token into refresh token and user token parts
-        Token._token_refresh_user[sandbox] = OAuthToken(
+        cls._token_refresh_user[sandbox] = OAuthToken(
             refresh_token=refresh_token.refresh_token,
             refresh_token_expiry=refresh_token.refresh_token_expiry)
-        Token._token_user[sandbox] = OAuthToken(
+        cls._token_user[sandbox] = OAuthToken(
             access_token=refresh_token.access_token,
             token_expiry=refresh_token.token_expiry)
 
-    @staticmethod
-    def _get_authorization_code(sign_in_url: str):
+    @classmethod
+    def _get_authorization_code(cls, sign_in_url: str):
         """Run the authorization flow in order to get an authorization code,
         which can subsequently be exchanged for a refresh (and user) token.
 
         :param
         sign_in_url (str): The redirect URL for gaining user consent
         """
-        Token._read_user_info()
+        cls._read_user_info()
 
         if "sandbox" in sign_in_url:
             env_key = "sandbox-user"
         else:
             env_key = "production-user"
 
-        userid = Token._user_credential_list[env_key][0]
-        password = Token._user_credential_list[env_key][1]
+        userid = cls._user_credential_list[env_key][0]
+        password = cls._user_credential_list[env_key][1]
 
         delay = 5  # delay seconds to give the page an opportunity to render
 
@@ -322,27 +322,27 @@ class Token:
 
         return code
 
-    @staticmethod
-    def _refresh_user_token(sandbox: bool):
+    @classmethod
+    def _refresh_user_token(cls, sandbox: bool):
         """Exchange a refresh token for a current user token."""
 
         # Get the list of scopes which resemble urls.
-        scopes = Token._user_scopes[sandbox]
+        scopes = cls._user_scopes[sandbox]
 
         if sandbox:
             env = Environment.SANDBOX
         else:
             env = Environment.PRODUCTION
 
-        user_token = Token._oauth2api_inst.get_access_token(
-            env, Token._token_refresh_user[sandbox].refresh_token, scopes)
+        user_token = cls._oauth2api_inst.get_access_token(
+            env, cls._token_refresh_user[sandbox].refresh_token, scopes)
 
         if user_token.access_token is None:
             raise Error(number=1, reason='user_token.access_token is None.')
         if len(user_token.access_token) == 0:
             raise Error(number=1, reason='user_token.access_token is of length zero.')
 
-        Token._token_user[sandbox] = user_token
+        cls._token_user[sandbox] = user_token
 
     @staticmethod
     def _read_user_info():
@@ -357,14 +357,14 @@ class Token:
                     if key in ['production-user', 'sandbox-user']:
                         userid = content[key]['username']
                         password = content[key]['password']
-                        Token._user_credential_list.update({key: [userid, password]})
+                        cls._user_credential_list.update({key: [userid, password]})
         except IOError:
             raise Error(number=1, reason='Unable to open ' + user_config_path)
 
-    @staticmethod
-    def _instantiate():
+    @classmethod
+    def _instantiate(cls):
 
-        if Token._oauth2api_inst is None:
+        if cls._oauth2api_inst is None:
             directory = os.getcwd()  # get the current working directory
             CredentialUtil.load(os.path.join(directory, 'ebay_rest.json'))
-            Token._oauth2api_inst = OAuth2Api()
+            cls._oauth2api_inst = OAuth2Api()


### PR DESCRIPTION
One more set that gets everything working for me:

1) Fix issue with apiz.ebay.com urls not being changed to apiz.sandbox.ebay.com URLS (fixes #1)
2) Fix issue when user_access_token is True, but params is None
3) Save a refresh token, obtained from the 'get user consent' feature, in Token as well as the current (short-lived) access token. Use this refresh token when the access token expires instead of going through the get user consent flow again.
4) Add a _set_credentials function to Token, which lets you set the Credentials for both application flow and user tokens (if you have a refresh token already, you can avoid getting user consent for another 18 months).
5) somewhat controversially: change all the staticmethods on Token that reference Token to classmethods. This means that you can actually subclass Token if you want and the subclass will change itself instead of changing the old class Token. Tweaked API so Token set as a class attribute so that it is trivial to subclass API to use a new subclassed Token (should anybody want to do that). Still not perfect as Token directly references and set attributes of the class CredentialUtil, but would still be a lot easier for someone to subclass for their use. The CredentialUtil problem is harder to fix as it is inherently tied into the design of the OAuth2API classes.