### PR TITLE
Allow subclassing of Token and API classes

### DIFF
--- a/src/ebay_rest/oath/credentialutil.py
+++ b/src/ebay_rest/oath/credentialutil.py
@@ -23,24 +23,22 @@ from .model.model import Environment, Credentials
 user_config_ids = ["sandbox-user", "production-user"]
 
 
-class CredentialUtil(object):
+class CredentialUtil():
     """
     credential_list: dictionary key=string, value=credentials
     """
     _credential_list = {}
 
-    @classmethod
-    def load(cls, app_config_path):
+    def load(self, app_config_path):
         logging.debug("Loading credential configuration file at: %s", app_config_path)
         with open(app_config_path, 'r') as f:
             if app_config_path.endswith('.json'):
                 content = json.loads(f.read())
             else:
                 raise ValueError('Configuration file need to be in JSON.')
-            CredentialUtil._iterate(content)
+            self._iterate(content)
 
-    @classmethod
-    def _iterate(cls, content):
+    def _iterate(self, content):
         for key in content:
             logging.debug("Environment attempted: %s", key)
 
@@ -51,18 +49,30 @@ class CredentialUtil(object):
                 ru_name = content[key]['redirecturi']
 
                 app_info = Credentials(client_id, client_secret, dev_id, ru_name)
-                cls._credential_list.update({key: app_info})
+                self._credential_list.update({key: app_info})
 
-    @classmethod
-    def get_credentials(cls, env_type):
+    def get_credentials(self, env_type):
         """
         env_config_id: environment.PRODUCTION.config_id or environment.SANDBOX.config_id
         """
-        if len(cls._credential_list) == 0:
+        if len(self._credential_list) == 0:
             msg = "No environment loaded from configuration file"
             logging.error(msg)
             raise CredentialNotLoadedError(msg)
-        return cls._credential_list[env_type.config_id]
+        return self._credential_list[env_type.config_id]
+
+    def update_credentials(self, sandbox: bool, credentials: Credentials):
+        """
+        Directly update the list of credentials.
+
+        :param
+        sandbox (bool): {True, False} For the sandbox True, for production False.
+
+        :param
+        credentials (Credentials): A Credentials instance.
+        """
+        key = Environment.SANDBOX.config_id if sandbox else Environment.PRODUCTION.config_id
+        self._credential_list.update({key: credentials})
 
 
 class CredentialNotLoadedError(Exception):

--- a/src/ebay_rest/token.py
+++ b/src/ebay_rest/token.py
@@ -321,21 +321,22 @@ class Token:
         time.sleep(delay)
 
         # get the result url and then close browser
-        parsed = parse_qs(browser.current_url, encoding='utf-8')
+        qs = browser.current_url.partition('?')[2]
+        parsed = parse_qs(qs, encoding='utf-8')
         browser.quit()
 
         is_auth_successful = False
-        if 'isAuthSuccessful' in parsed:
-            if 'true' == parsed['isAuthSuccessful'][0]:
-                is_auth_successful = True
+        # Chech isAuthSuccessful is true, if present
+        # Assume authorization was successful if isAuthSuccessful missing
+        is_auth_successful = parsed.get('isAuthSuccessful', ['true'])[0]
         if not is_auth_successful:
-            reason = "Authorization unsuccessful, check userid & password: " + userid + " " + password
+            reason = (
+                f"Authorization unsuccessful, check userid & password: {userid} {password}"
+            )
             raise Error(number=1, reason=reason)
 
-        code = None
-        if 'code' in parsed:
-            if parsed['code'][0]:
-                code = parsed['code'][0]
+        # Check we have the code in the browser URL
+        code = parsed.get('code', [False])[0]
         if not code:
             raise Error(number=1, reason="Unable to obtain code.")
 

--- a/src/ebay_rest/token.py
+++ b/src/ebay_rest/token.py
@@ -326,7 +326,7 @@ class Token:
         browser.quit()
 
         is_auth_successful = False
-        # Chech isAuthSuccessful is true, if present
+        # Check isAuthSuccessful is true, if present
         # Assume authorization was successful if isAuthSuccessful missing
         is_auth_successful = parsed.get('isAuthSuccessful', ['true'])[0]
         if not is_auth_successful:


### PR DESCRIPTION
I've changed a few things so that subclassing everything, should anyone want to do it, would be much easier.

The Token class remains as a class object thing, to allow sharing of credentials across API instances, but the CredentialUtil class is now added as an instance to the Token class. I've also changed the way OAuth2Api is written so that it would work if subclassed.

Separately, I don't use the standard eBay redirect 'success' URL and there was a bug in the parsing of the query string which was breaking the authorization flow for me (plus because of complicated redirect nonsense, I don't have 'isAuthSuccessful' so I've made 'success' the default if the param is missing entirely).

Finally, I've tidied up the tests - one more now uses the sandbox instead of production by using 'black' instead of 'silver' (couldn't get it to work for the one remaining production test irritatingly), fixed a bug when an item has no ShippingOptions or when it has no RegionsExcluded(?), and used self.fail(msg) instead of self.assertTrue(False, msg).

You can, of course, decide you hate everything I've done and throw it away - I've got the key stuff I need working now with your last release (thanks!) so while I am happy to help with anything, the latest release does what I need it to.

I don't think any of this actually adds any functionality (other than the bug with authorization flow URL parsing I guess) so I'd suggest doesn't need releasing in a new version or anything.

Thanks again for writing this, the timing of which was extremely convenient as Managed Payments forced us to look at the OAuth APIs just a few weeks ago! :)