### PR TITLE
fix: Return whole pages by default for _method_pages; pass record_key_list to get old behaviour

### DIFF
--- a/src/ebay_rest/a_p_i.py
+++ b/src/ebay_rest/a_p_i.py
@@ -330,14 +330,16 @@ class API:
                 result = self._call_swagger(swagger_method, params, kwargs, object_error)
             except Error:
                 raise
-            offset += result['limit']
+            offset += result['limit'] or 0
 
             if record_list_key is None:
                 # Yield the full result with each iteration
                 yield result
             else:
+                if not result.get(record_list_key):
+                    return  # No entries to return
                 # Generator returns one entry per iteration
-                for element in result.get(record_list_key, []):
+                for element in result['record_list_key']:
                     yield element
                     if records_desired is not None:
                         records_yielded += 1


### PR DESCRIPTION
See issue #8 

Currently for all paged calls, when you make the API call you get a generator back. Each iteration of the generator, if necessary, makes a page request. It then yields a single element of (hopefully) what you were looking to obtain (e.g. orders for get_orders). This makes building a list of these, or dealing with them, very easy, but there are some potential issues which this method and its implementation.

1. A guess is made at the entry of interest by looking through the response for a list. If the response contains any other lists, e.g. the buy_browse_search call which may return an autoCorrections container, then the wrong entry may be returned.
2. Warnings are lost (unless they accidentally get selected as the entry of interest, in which case all you get is the warnings).

To deal with this, I propose adding a 'record_list_key' keyword parameter, default value None, to method_paged. When set to None, api calls will return of list of the complete response from each API call (including prev, next, limit, offset, total etc). This would also include any warnings or additional list entries (such as autoCorrections). However, this does mean the user needs to spend a (trivial) amount of extra time assembling their fields of choice.
Another issue is that it is not possible to limit the number of records exactly, as it is not known which element is actually to be limited. It is possible to only retrieve the necessary number of pages, however, so a user may get 400 elements (two pages) when they only want 350, but they will not get 10,000.

If the user supplies a record_list_key, then the previous behaviour will apply, except that now there is no need for guessing the correct list element so the correct field of interest will always be returned. It is, as before, trivial to return exactly the desired number of elements to the user (and to discard additional elements returned with the final page).

THIS IS A BREAKING CHANGE - another option would be to make 'auto' the record_key_list default which would attempt to guess the correct response field that is being paged, which would preserve the current default behaviour.