### PR TITLE
fix: Better discrimination of paged vs single calls

### DIFF
--- a/scripts/process_api_cache.py
+++ b/scripts/process_api_cache.py
@@ -238,13 +238,8 @@ class Process:
         if has_docstring_problem:
             pass    # TODO Do something to make the comments aka docstring handle optional parameters properly
 
-        # prepare the method type
-        method_type = 'single'      # most calls are of this type
-        for line in docstring.split('\n'):
-            if ':return:' in line:
-                if 'Paged' in line:
-                    method_type = 'paged'
-                    break
+        # prepare the method type by testing for 'offset' parameter
+        method_type = 'paged' if (':param str offset' in docstring) else 'single'
 
         # identify if this is a user_access_token routine
         scopes = self.scopes[name]


### PR DESCRIPTION
Currently, process_api_cache.py tests method docstrings for a return argument with 'Paged' in its name. This identifies many cases of paginated API calls, but misses many and gives one false positive (getShippingFulfillments in sell_fulfillments is not paginated).
Better is to test for `:param str offset` which identifies all the methods previously identified as paginated (except the false positive) but identifies many more, such as sell_finance's getTransactions.

Note that I have _not_ actually run generate_api_cache or process_api_cache in this pull request; this should probably be done to correct a_p_i.py etc. but would add more confusion than necessary here.