### PR TITLE
fix: Method paged automatic alternative

### DIFF
--- a/src/ebay_rest/a_p_i.py
+++ b/src/ebay_rest/a_p_i.py
@@ -330,14 +330,16 @@ class API:
                 result = self._call_swagger(swagger_method, params, kwargs, object_error)
             except Error:
                 raise
-            offset += result['limit']
+            offset += result['limit'] or 0
 
             if record_list_key is None:
                 # Yield the full result with each iteration
                 yield result
             else:
+                if not result.get(record_list_key):
+                    return  # No entries to return
                 # Generator returns one entry per iteration
-                for element in result.get(record_list_key, []):
+                for element in result['record_list_key']:
                     yield element
                     if records_desired is not None:
                         records_yielded += 1


### PR DESCRIPTION
This is an alternative to pull request #9 which gives the same functionality but the _default_ behaviour remains the same, as record_list_key by default is 'auto', and it has to be set to None explicitly if you want to get whole pages back.

I am mostly indifferent about which approach is taken, as long as I can actually get the full pages...