### PR TITLE
fix: Wrap type() in str() before trying to concatenate with string

### DIFF
--- a/src/ebay_rest/a_p_i.py
+++ b/src/ebay_rest/a_p_i.py
@@ -317,7 +317,7 @@ class API:
                 detail = "The parameter " + param_name + " should not be None or the configuration file should exist."
 
         else:
-            detail = "Parameter " + param_name + " must be a Dict, String or None but it is a " + type(parameter) + "."
+            detail = "Parameter " + param_name + " must be a Dict, String or None but it is a " + str(type(parameter)) + "."
 
         if result is None:
             raise Error(number=1, reason="Get configuration for " + param_name + " problem.", detail=detail)


### PR DESCRIPTION
type(param) returns a 'type' object, not a string. It must be wrapped in str() before being concatenated with other strings.

Using f-strings would be much easier, but I have left it as normal string addition to match existing style.