### PR TITLE
Gbm001 fix scopes

### DIFF
--- a/src/ebay_rest/token.py
+++ b/src/ebay_rest/token.py
@@ -415,7 +415,8 @@ class _OAuth2Api:
         logging.debug("Trying to get a new user access token ... ")
 
         headers = self._generate_request_headers()
-        body = self._generate_refresh_request_body(scopes, refresh_token)
+        body = self._generate_refresh_request_body(
+            ' '.join(scopes), refresh_token)
         api_endpoint = self._get_endpoint()
         resp = requests.post(api_endpoint, data=body, headers=headers)
         content = json.loads(resp.content)


### PR DESCRIPTION
When getting a new User Access Token using an existing refresh token, the scopes must be concatenated together with spaces before being passed to requests. Otherwise, you will successfully get a User Access Token but it will fail with error 403 if you need to actually use it for anything that needs a scope.

I think this is how it was in the original code anyway...