### PR TITLE
fix: bug when using single section in ebay_rest.json and not specifying section name

### DIFF
--- a/src/ebay_rest/a_p_i.py
+++ b/src/ebay_rest/a_p_i.py
@@ -356,7 +356,7 @@ class API(metaclass=Multiton):
                 if section in config_contents:
                     sections = config_contents['applications'].keys()
                     if len(sections) == 1:
-                        result = config_contents['applications'][sections[0]]
+                        result = config_contents['applications'][tuple(sections)[0]]
                     else:
                         detail = "Perhaps parameter " + param_name + " should be one of " + ", ".join(sections) + "."
                 else:


### PR DESCRIPTION
In Py3, dict_keys objects are iterable but not indexable; in the single-value case convert to a tuple before retrieving 'first' (only) value.

Trying to create an API object without specifying the sections in ebay_rest.json (permitted when there is only one section in the ebay_rest.json file for applications/user etc) fails. This fixes that issue.