### PR TITLE
fix: bug when using single section in ebay_rest.json (attempt 2)

### DIFF
--- a/src/ebay_rest/a_p_i.py
+++ b/src/ebay_rest/a_p_i.py
@@ -354,9 +354,9 @@ class API(metaclass=Multiton):
         elif parameter is None:
             if config_contents:
                 if section in config_contents:
-                    sections = config_contents['applications'].keys()
+                    sections = config_contents[section].keys()
                     if len(sections) == 1:
-                        result = config_contents['applications'][sections[0]]
+                        result = config_contents[section][tuple(sections)[0]]
                     else:
                         detail = "Perhaps parameter " + param_name + " should be one of " + ", ".join(sections) + "."
                 else:


### PR DESCRIPTION
In Py3, dict_keys objects are iterable but not indexable; in the single-value case convert to a tuple before retrieving 'first' (only) value.

Trying to create an API object without specifying the sections in ebay_rest.json (permitted when there is only one section in the ebay_rest.json file for applications/user etc) fails. This fixes that issue.

Secondly, 'applications' is hard-coded in which means it always returns the 'applications' dict and not the one requested (e.g. 'user').

Arguably there should be a check that the single 'application' section has the same name as the single 'user' section etc., but I have not implemented this. If you just left the `sections = config_contents['applications'].keys()` line as it was, this would be enforced, but it would fail with a KeyError if the sections weren't aimed for (an additional check would be needed). I went for simplicity and decided it probably didn't really matter...