### PR TITLE
Fix issue when reason or detail is actually a bytes object

### DIFF
--- a/src/ebay_rest/error.py
+++ b/src/ebay_rest/error.py
@@ -34,9 +34,6 @@ class Error(Exception):
         """
         :return message (str)
         """
-        message = 'Error number' + str(self.number) + '.'
-        if self.reason:
-            message = message + ' ' + self.reason
-        if self.detail:
-            message = message + ' ' + self.detail
-        return message
+        message = 'Error number {}. {} {}'.format(
+            self.number, self.reason or '', self.detail or '')
+        return message.rstrip()


### PR DESCRIPTION
Direct string concatenation is very clunky and doesn't work for mixing strings and bytes objects. If detail or reason is actually a bytes object (or any other object with a `__str__` method), this won't work. Using str.format allows values to be intelligently inserted into the output strings. **Without this (or otherwise casting reason or detail to strings), I get a TypeError for some calls** (e.g. createSigningKey in the Developer Key Management API which, in classic eBay style, fails on the sandbox even though it shouldn't...)

If detail is supplied but reason is not, you do get an extra space (if you are missing detail or both, the rstrip takes care of it). Fixing this is trivial but would create unnecessarily complicated code.

I'd prefer to use f-strings, because they are much clearer than str.format (and actually faster than direct string concatenation), but I don't know what antiquated versions of Python are being supported by eBay. There are no supported versions of CPython that don't support f-strings.