### PR TITLE
Fix typo in token.py in digital signatures

### DIFF
--- a/src/ebay_rest/token.py
+++ b/src/ebay_rest/token.py
@@ -749,7 +749,7 @@ class KeyPairToken(metaclass=Multiton):
             # An expired key must be replaced
             self._create_key_pair(api)
 
-        elif self.expiration_time and self.jwe and self.private_key:
+        elif self._expiration_time and self._jwe and self._private_key:
             # If we have enough information to try an API call plus the
             # (in date) expiration time, assume the details are valid
             return


### PR DESCRIPTION
Slightly embarrassing typo in my last-minute fix to the now-merged pull request...

(personally I'm not a big fan of single underscore prefixes in Python except for exceptional cases...)