### PR TITLE
fix(digital_signatures): Fix erroneous string encoding for calls with digital signatures and a body

### DIFF
--- a/src/ebay_rest/digital_signatures.py
+++ b/src/ebay_rest/digital_signatures.py
@@ -20,8 +20,9 @@ def signed_request(pool_manager, key_pair, method, url, *_args, **kwargs):
     # If we have a body, we need to add a Content-Digest field
     if 'body' in kwargs:
         content = kwargs['body']
-        h = hashlib.sha256(content).digest()
-        content_digest = f'sha-256=:{base64.b64encode(h)}:'
+        h = hashlib.sha256(content.encode('utf-8')).digest()
+        b64_hash = base64.b64encode(h).decode('utf-8')
+        content_digest = f'sha-256=:{b64_hash}:'
         headers['Content-Digest'] = content_digest
         signature_fields = {'content-digest': content_digest}
     else:


### PR DESCRIPTION
A rookie mistake on my part...

I failed to properly encode a bytestring back into a str prior to string manipulations lead to a literal `b'` and `'` in the Content-Digest header.

Calls using Digital Signatures that have a body were broken as the signature was incorrectly calculated. There are very few (one?) calls that need Digital Signatures that accept a body parameter, but since currently all calls get a digital signature when Digital Signatures are in use, this cropped up using a call that does use a body.