### PR TITLE
Added Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,8 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+docs/build/
+docs/source/
 
 # PyBuilder
 target/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,27 @@
+# Read the Docs configuration file
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+# Install dependencies
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev
+
+# Build configuration and commands
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  commands:
+    # Generate documentation source files before Sphinx builds
+    - python -c "import sys; sys.path.insert(0, '.'); from docs.build_docs import generate_documentation_source; generate_documentation_source()"
+
+# Build documentation
+sphinx:
+  configuration: docs/source/conf.py
+  builder: html
+

--- a/docs/api.rst.template
+++ b/docs/api.rst.template
@@ -1,0 +1,8 @@
+API Reference
+============
+
+.. toctree::
+   :maxdepth: 2
+
+{api_groups}
+

--- a/docs/api_group.rst.template
+++ b/docs/api_group.rst.template
@@ -1,0 +1,7 @@
+{group_title}
+{group_title_underline}
+
+.. currentmodule:: ebay_rest.API
+
+{methods}
+

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+Build Sphinx documentation for ebay_rest.
+
+This script:
+1. Reads source code from the repo (src/ebay_rest/)
+2. Generates RST files automatically to docs/source/
+3. Creates Sphinx configuration
+4. Builds HTML documentation
+5. Outputs to docs/build/
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+from sphinx.application import Sphinx
+from sphinx.util.docutils import docutils_namespace
+
+
+def get_project_root():
+    """Get the project root directory."""
+    # This script is in docs/, so go up one level
+    return Path(__file__).parent.parent.absolute()
+
+
+def get_api_file_path(project_root):
+    """Get the path to the API file in the repo."""
+    api_path = project_root / "src" / "ebay_rest" / "a_p_i.py"
+    if not api_path.exists():
+        raise FileNotFoundError(f"API file not found at {api_path}")
+    return api_path
+
+
+def create_conf_py(docs_dir, project_root):
+    """Create the Sphinx conf.py file from template."""
+    # Calculate relative path from source_dir to src
+    source_dir = docs_dir / "source"
+    src_path = project_root / "src"
+    rel_path = os.path.relpath(src_path, source_dir)
+
+    # Read template file
+    template_path = docs_dir / "conf.py.template"
+    if not template_path.exists():
+        raise FileNotFoundError(f"Template not found: {template_path}")
+
+    with open(template_path, "r", encoding="utf-8") as f:
+        conf_content = f.read().format(src_path=rel_path)
+
+    # conf.py must be in the source directory for Sphinx
+    conf_path = docs_dir / "source" / "conf.py"
+    with open(conf_path, "w", encoding="utf-8") as f:
+        f.write(conf_content)
+    print(f"✓ Created {conf_path}")
+
+
+def extract_methods(api_path):
+    """Extract all public methods from the API class."""
+    with open(api_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    # Find all method definitions in the API class
+    methods = []
+    in_api_class = False
+    api_class_indent = None
+
+    for i, line in enumerate(lines):
+        # Check if we're entering the API class
+        if re.match(r"^class\s+API\s*\(", line):
+            in_api_class = True
+            # Get the indentation level (should be 0, but check anyway)
+            api_class_indent = len(line) - len(line.lstrip())
+            continue
+
+        # Check if we're leaving the API class (another class definition at same or less indent)
+        if in_api_class:
+            stripped = line.lstrip()
+            if stripped and not stripped.startswith("#"):
+                current_indent = len(line) - len(stripped)
+                # If we hit a class definition at same or less indent, we've left API class
+                if current_indent <= api_class_indent and re.match(
+                    r"^class\s+\w+", stripped
+                ):
+                    break
+
+        if in_api_class:
+            # Look for method definitions (4 spaces indent for class methods)
+            match = re.match(r"^\s{4}def\s+([a-z_][a-z0-9_]*)\s*\(", line)
+            if match:
+                method_name = match.group(1)
+                # Include all methods (including __init__), skip truly private ones
+                if not method_name.startswith("_") or method_name == "__init__":
+                    methods.append(method_name)
+
+    return methods
+
+
+def group_methods(methods):
+    """Group methods by their prefix (e.g., buy_browse, sell_inventory)."""
+    groups = {}
+    for method in methods:
+        if method == "__init__":
+            groups["__init__"] = [method]
+            continue
+
+        # Extract prefix (first two parts: buy_browse, sell_inventory, etc.)
+        parts = method.split("_")
+        if len(parts) >= 2:
+            prefix = "_".join(parts[:2])
+        else:
+            prefix = parts[0]
+
+        if prefix not in groups:
+            groups[prefix] = []
+        groups[prefix].append(method)
+
+    return groups
+
+
+def generate_rst_files(docs_dir, method_groups, project_root=None):
+    """Generate RST files for the documentation from templates."""
+    if project_root is None:
+        project_root = docs_dir.parent
+    source_dir = docs_dir / "source"
+    api_dir = source_dir / "api"
+    api_dir.mkdir(parents=True, exist_ok=True)
+
+    # Read templates
+    api_template_path = docs_dir / "api.rst.template"
+    group_template_path = docs_dir / "api_group.rst.template"
+    index_rst_path = docs_dir / "index.rst"
+
+    if not api_template_path.exists():
+        raise FileNotFoundError(f"Template not found: {api_template_path}")
+    if not group_template_path.exists():
+        raise FileNotFoundError(f"Template not found: {group_template_path}")
+    if not index_rst_path.exists():
+        raise FileNotFoundError(f"Template not found: {index_rst_path}")
+
+    with open(api_template_path, "r", encoding="utf-8") as f:
+        api_template = f.read()
+    with open(group_template_path, "r", encoding="utf-8") as f:
+        group_template = f.read()
+    with open(index_rst_path, "r", encoding="utf-8") as f:
+        index_content = f.read()
+
+    # Generate API group entries for main API index
+    api_groups = []
+
+    # Generate RST files for each method group
+    for prefix, methods in sorted(method_groups.items()):
+        if prefix == "__init__":
+            continue
+
+        # Add to main API index
+        api_groups.append(f"   api/{prefix}")
+
+        # Create group RST file
+        group_title = " ".join(word.capitalize() for word in prefix.split("_"))
+        group_title_underline = "=" * len(group_title)
+
+        # Generate method entries
+        method_entries = "\n".join(
+            f".. automethod:: ebay_rest.API.{method}\n" for method in sorted(methods)
+        )
+
+        group_rst_content = group_template.format(
+            group_title=group_title,
+            group_title_underline=group_title_underline,
+            methods=method_entries,
+        )
+
+        group_file = api_dir / f"{prefix}.rst"
+        with open(group_file, "w", encoding="utf-8") as f:
+            f.write(group_rst_content)
+        print(f"✓ Generated {group_file}")
+
+    # Write main API index
+    api_rst_content = api_template.format(api_groups="\n".join(api_groups))
+    api_rst_file = source_dir / "api.rst"
+    with open(api_rst_file, "w", encoding="utf-8") as f:
+        f.write(api_rst_content)
+    print(f"✓ Generated {api_rst_file}")
+
+    # Copy README.md to source directory
+    readme_path = project_root / "README.md"
+    if readme_path.exists():
+        with open(readme_path, "r", encoding="utf-8") as f:
+            readme_content = f.read()
+
+        readme_md_dest = source_dir / "readme.md"
+        with open(readme_md_dest, "w", encoding="utf-8") as f:
+            f.write(readme_content)
+        print(f"✓ Copied README.md to {readme_md_dest}")
+    else:
+        print(f"⚠ Warning: README.md not found at {readme_path}")
+
+    # Copy main index (static file, not a template)
+    index_file = source_dir / "index.rst"
+    with open(index_file, "w", encoding="utf-8") as f:
+        f.write(index_content)
+    print(f"✓ Generated {index_file}")
+
+
+def create_directories(docs_dir):
+    """Create necessary directories."""
+    (docs_dir / "source" / "api").mkdir(parents=True, exist_ok=True)
+    print("✓ Created directory structure")
+
+
+def build_documentation(docs_dir):
+    """Build the HTML documentation using Sphinx."""
+    build_dir = docs_dir / "build"
+    source_dir = docs_dir / "source"
+    doctree_dir = docs_dir / "build" / ".doctrees"
+
+    print("\nBuilding documentation...")
+    try:
+        with docutils_namespace():
+            app = Sphinx(
+                srcdir=str(source_dir),
+                confdir=str(source_dir),
+                outdir=str(build_dir),
+                doctreedir=str(doctree_dir),
+                buildername="html",
+                confoverrides={},
+                status=None,  # Use default status output
+                warning=None,  # Use default warning output
+                freshenv=False,
+                warningiserror=False,
+                tags=None,
+                verbosity=1,
+                parallel=0,  # 0 = auto-detect
+            )
+            app.build()
+
+        print("✓ Documentation built successfully!")
+        print(f"✓ Output available at: {build_dir / 'index.html'}")
+        return True
+    except Exception as e:
+        print(f"✗ Error building documentation:")
+        print(f"  {type(e).__name__}: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def generate_documentation_source(docs_dir=None, project_root=None):
+    """
+    Generate documentation source files (RST and conf.py) without building.
+    """
+    if project_root is None:
+        project_root = get_project_root()
+    if docs_dir is None:
+        docs_dir = project_root / "docs"
+
+    docs_dir.mkdir(exist_ok=True)
+
+    # Get API file path from repo
+    api_path = get_api_file_path(project_root)
+    print(f"✓ Found API file: {api_path}")
+
+    # Extract methods
+    print("\nExtracting methods from API class...")
+    methods = extract_methods(api_path)
+    print(f"✓ Found {len(methods)} methods")
+
+    # Group methods
+    method_groups = group_methods(methods)
+    print(f"✓ Grouped into {len(method_groups)} categories")
+
+    # Create directories
+    print("\nCreating directory structure...")
+    create_directories(docs_dir)
+
+    # Generate configuration
+    print("\nGenerating Sphinx configuration...")
+    create_conf_py(docs_dir, project_root)
+
+    # Generate RST files
+    print("\nGenerating RST files...")
+    generate_rst_files(docs_dir, method_groups, project_root)
+
+    print("\n✓ Documentation source files generated successfully!")
+    return True
+
+
+def main():
+    """Main function to build documentation."""
+    print("Building ebay_rest documentation...\n")
+
+    project_root = get_project_root()
+    docs_dir = project_root / "docs"
+
+    # Generate source files
+    if not generate_documentation_source(docs_dir, project_root):
+        sys.exit(1)
+
+    # Build documentation
+    print("\n" + "=" * 50)
+    success = build_documentation(docs_dir)
+
+    if success:
+        print("\n" + "=" * 50)
+        print("\nDocumentation build complete!")
+    else:
+        print("\nDocumentation build failed. Please check the errors above.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/conf.py.template
+++ b/docs/conf.py.template
@@ -1,0 +1,56 @@
+# Configuration file for the Sphinx documentation builder.
+#
+
+# -- Project information -----------------------------------------------------
+project = 'ebay_rest'
+copyright = '2025, Peter JOHN Matecsa & ebay_rest contributors'
+author = 'Peter JOHN Matecsa & ebay_rest contributors'
+
+# -- General configuration ---------------------------------------------------
+import os
+import sys
+
+# Add the project source to the path
+sys.path.insert(0, os.path.abspath('{src_path}'))
+
+extensions = [
+    'myst_parser',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme',
+]
+
+# Markdown configuration
+myst_enable_extensions = [
+    'colon_fence',
+    'deflist',
+    'html_admonition',
+    'html_image',
+    'replacements',
+    'smartquotes',
+    'strikethrough',
+    'substitution',
+    'tasklist',
+]
+
+# Paths relative to this conf.py file (in source/)
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# -- Options for HTML output -------------------------------------------------
+html_theme = 'sphinx_rtd_theme'
+html_theme_options = {{
+    'style_nav_header_background': '#2b2b2b',
+    'style_external_links': True,
+    'navigation_depth': 4,
+}}
+
+autodoc_member_order = 'bysource'
+autodoc_typehints = 'description'
+autodoc_default_options = {{
+    'members': True,
+    'undoc-members': True,
+    'show-inheritance': True,
+    'special-members': '__init__',
+}}
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,12 @@
+ebay_rest Documentation
+========================
+
+Welcome to the ebay_rest documentation. Note: Api references are automaticall generated and come from eBay's OpenAPI Specs.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   readme
+   api
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,11 @@ dev = [
     "build",
     "chardet",
     "CurrencyConverter",
+    "myst-parser",
     "pipreqs",
     "setuptools",
+    "sphinx",
+    "sphinx-rtd-theme",
     "twine",
     "wheel"
 ]


### PR DESCRIPTION
## Add Documentation Generation with Sphinx and Read the Docs Integration

Fixes #13 Thanks to @seedlord for the original code that generates the RST files.
This pull request adds a `docs` folder and introduces automated documentation generation using Sphinx.

### Summary
- Added `build_docs.py` script to generate RST files in `docs/source` and build the documentation to `docs/build`.
- The script scans the library’s `src` directory and extracts docstrings (based on eBay’s OpenAPI specifications) to create API references for this library.
- Automatically includes this project’s main README in the documentation.
- Configured Sphinx to produce HTML documentation.
- Added `.readthedocs.yml` configuration file to enable hosting on Read the Docs for free. (see Next Steps)

### Local Usage
Run the following commands to build the documentation locally to the `docs/build` folder:
```bash
python3 -m pip install -e ".[dev]"
cd docs
python build_docs.py
```

### Next Steps

Connect the repository to [Read the Docs](https://readthedocs.org) to enable free automatic documentation builds and hosting. This PR already includes a `.readthedocs.yml` config file to make this straightforward.
