### PR TITLE
Patched Commerce_Media_Upload_Video

### DIFF
--- a/src/ebay_rest/a_p_i_private.py
+++ b/src/ebay_rest/a_p_i_private.py
@@ -983,7 +983,7 @@ class APIPrivate(metaclass=Multiton):
             return new_dict
 
         else:
-            logging.debug("Unexpected object of type " + type(obj) + ".")
+            logging.debug(f"Unexpected object of type {type(obj)}.")
             return obj  # something needs to be returned, hopefully it is useful as is
 
     def _call_swagger(

--- a/src/ebay_rest/api/buy_browse/api/item_api.py
+++ b/src/ebay_rest/api/buy_browse/api/item_api.py
@@ -51,7 +51,8 @@ class ItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.check_compatibility_with_http_info(content_type, item_id, **kwargs)  # noqa: E501
         else:
@@ -171,7 +172,8 @@ class ItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_item_with_http_info(item_id, **kwargs)  # noqa: E501
         else:
@@ -288,7 +290,8 @@ class ItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_item_by_legacy_id_with_http_info(legacy_item_id, **kwargs)  # noqa: E501
         else:
@@ -409,7 +412,8 @@ class ItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_items_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -520,7 +524,8 @@ class ItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_items_by_item_group_with_http_info(item_group_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_browse/api/item_summary_api.py
+++ b/src/ebay_rest/api/buy_browse/api/item_summary_api.py
@@ -62,7 +62,8 @@ class ItemSummaryApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.search_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -210,7 +211,8 @@ class ItemSummaryApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.search_by_image_with_http_info(content_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_browse/rest.py
+++ b/src/ebay_rest/api/buy_browse/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/buy_deal/api/deal_item_api.py
+++ b/src/ebay_rest/api/buy_deal/api/deal_item_api.py
@@ -53,7 +53,8 @@ class DealItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_deal_items_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_deal/api/event_api.py
+++ b/src/ebay_rest/api/buy_deal/api/event_api.py
@@ -49,7 +49,8 @@ class EventApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_event_with_http_info(x_ebay_c_marketplace_id, event_id, **kwargs)  # noqa: E501
         else:
@@ -157,7 +158,8 @@ class EventApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_events_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_deal/api/event_item_api.py
+++ b/src/ebay_rest/api/buy_deal/api/event_item_api.py
@@ -53,7 +53,8 @@ class EventItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_event_items_with_http_info(event_ids, x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_deal/rest.py
+++ b/src/ebay_rest/api/buy_deal/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/buy_feed/api/access_api.py
+++ b/src/ebay_rest/api/buy_feed/api/access_api.py
@@ -46,7 +46,8 @@ class AccessApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_access_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_feed/api/feed_type_api.py
+++ b/src/ebay_rest/api/buy_feed/api/feed_type_api.py
@@ -47,7 +47,8 @@ class FeedTypeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_feed_type_with_http_info(feed_type_id, **kwargs)  # noqa: E501
         else:
@@ -145,7 +146,8 @@ class FeedTypeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_feed_types_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_feed/api/file_api.py
+++ b/src/ebay_rest/api/buy_feed/api/file_api.py
@@ -49,7 +49,8 @@ class FileApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.download_file_with_http_info(file_id, x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -155,7 +156,8 @@ class FileApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_file_with_http_info(file_id, x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -263,7 +265,8 @@ class FileApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_files_with_http_info(feed_type_id, x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_feed/rest.py
+++ b/src/ebay_rest/api/buy_feed/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/buy_marketing/api/merchandised_product_api.py
+++ b/src/ebay_rest/api/buy_marketing/api/merchandised_product_api.py
@@ -50,7 +50,8 @@ class MerchandisedProductApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_merchandised_products_with_http_info(category_id, metric_name, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_marketing/rest.py
+++ b/src/ebay_rest/api/buy_marketing/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/buy_offer/api/bidding_api.py
+++ b/src/ebay_rest/api/buy_offer/api/bidding_api.py
@@ -48,7 +48,8 @@ class BiddingApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_bidding_with_http_info(item_id, x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -153,7 +154,8 @@ class BiddingApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.place_proxy_bid_with_http_info(x_ebay_c_marketplace_id, content_type, item_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_offer/rest.py
+++ b/src/ebay_rest/api/buy_offer/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/buy_order/api/guest_checkout_session_api.py
+++ b/src/ebay_rest/api/buy_order/api/guest_checkout_session_api.py
@@ -51,7 +51,8 @@ class GuestCheckoutSessionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.apply_guest_coupon_with_http_info(x_ebay_c_marketplace_id, content_type, checkout_session_id, **kwargs)  # noqa: E501
         else:
@@ -172,7 +173,8 @@ class GuestCheckoutSessionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_guest_checkout_session_with_http_info(checkout_session_id, x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -280,7 +282,8 @@ class GuestCheckoutSessionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.initiate_guest_checkout_session_with_http_info(x_ebay_c_marketplace_id, content_type, **kwargs)  # noqa: E501
         else:
@@ -396,7 +399,8 @@ class GuestCheckoutSessionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.remove_guest_coupon_with_http_info(x_ebay_c_marketplace_id, content_type, checkout_session_id, **kwargs)  # noqa: E501
         else:
@@ -519,7 +523,8 @@ class GuestCheckoutSessionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_guest_quantity_with_http_info(x_ebay_c_marketplace_id, content_type, checkout_session_id, **kwargs)  # noqa: E501
         else:
@@ -642,7 +647,8 @@ class GuestCheckoutSessionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_guest_shipping_address_with_http_info(x_ebay_c_marketplace_id, content_type, checkout_session_id, **kwargs)  # noqa: E501
         else:
@@ -765,7 +771,8 @@ class GuestCheckoutSessionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_guest_shipping_option_with_http_info(x_ebay_c_marketplace_id, content_type, checkout_session_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_order/api/guest_purchase_order_api.py
+++ b/src/ebay_rest/api/buy_order/api/guest_purchase_order_api.py
@@ -49,7 +49,8 @@ class GuestPurchaseOrderApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_guest_purchase_order_with_http_info(purchase_order_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/buy_order/rest.py
+++ b/src/ebay_rest/api/buy_order/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/commerce_catalog/api/product_api.py
+++ b/src/ebay_rest/api/commerce_catalog/api/product_api.py
@@ -48,7 +48,8 @@ class ProductApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_product_with_http_info(epid, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_catalog/api/product_summary_api.py
+++ b/src/ebay_rest/api/commerce_catalog/api/product_summary_api.py
@@ -55,7 +55,8 @@ class ProductSummaryApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.search_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_catalog/rest.py
+++ b/src/ebay_rest/api/commerce_catalog/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/commerce_charity/api/charity_org_api.py
+++ b/src/ebay_rest/api/commerce_charity/api/charity_org_api.py
@@ -48,7 +48,8 @@ class CharityOrgApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_charity_org_with_http_info(charity_org_id, x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -154,7 +155,8 @@ class CharityOrgApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_charity_orgs_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_charity/rest.py
+++ b/src/ebay_rest/api/commerce_charity/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/commerce_identity/api/user_api.py
+++ b/src/ebay_rest/api/commerce_identity/api/user_api.py
@@ -46,7 +46,8 @@ class UserApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_user_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_identity/rest.py
+++ b/src/ebay_rest/api/commerce_identity/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/commerce_media/api/document_api.py
+++ b/src/ebay_rest/api/commerce_media/api/document_api.py
@@ -48,7 +48,8 @@ class DocumentApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_document_with_http_info(content_type, **kwargs)  # noqa: E501
         else:
@@ -151,7 +152,8 @@ class DocumentApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_document_from_url_with_http_info(content_type, **kwargs)  # noqa: E501
         else:
@@ -253,7 +255,8 @@ class DocumentApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_document_with_http_info(document_id, **kwargs)  # noqa: E501
         else:
@@ -350,7 +353,8 @@ class DocumentApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.upload_document_with_http_info(document_id, content_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_media/api/image_api.py
+++ b/src/ebay_rest/api/commerce_media/api/image_api.py
@@ -48,7 +48,8 @@ class ImageApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_image_from_file_with_http_info(content_type, **kwargs)  # noqa: E501
         else:
@@ -148,7 +149,8 @@ class ImageApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_image_from_url_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -254,7 +256,8 @@ class ImageApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_image_with_http_info(image_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_media/api/video_api.py
+++ b/src/ebay_rest/api/commerce_media/api/video_api.py
@@ -18,6 +18,7 @@ import re  # noqa: F401
 import six
 
 from ...commerce_media.api_client import ApiClient
+import os  # noqa: F401  # ebay_rest patch: application/octet-stream file uploads
 
 
 class VideoApi(object):
@@ -48,7 +49,8 @@ class VideoApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_video_with_http_info(content_type, **kwargs)  # noqa: E501
         else:
@@ -146,7 +148,8 @@ class VideoApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_video_with_http_info(video_id, **kwargs)  # noqa: E501
         else:
@@ -237,6 +240,7 @@ class VideoApi(object):
 
         :param async_req bool
         :param str content_type: Use this header to specify the content type for the upload. The Content-Type should be set to <code>application/octet-stream</code>. (required)
+        :param dict files: Dictionary mapping field names to file paths. For example: {'file': 'path/to/video.mp4'}. The file will be read and sent as the request body for application/octet-stream uploads. (optional)  # ebay_rest patch: application/octet-stream file uploads
         :param str video_id: The unique identifier of the video to be uploaded. (required)
         :param InputStream body: The request payload for this method is the input stream for the video source. The input source must be an .mp4 file of the type MPEG-4 Part 10 or Advanced Video Coding (MPEG-4 AVC).
         :param str content_length: Use this header to specify the content length for the upload. Use Content-Range: bytes {1}-{2}/{3} and Content-Length:{4} headers.<br /><br /><span class=\"tablenote\"><span style=\"color:#004680\"><strong>Note:</strong></span> This header is optional and is only required for <i>resumable</i> uploads (when an upload is interrupted and must be resumed from a certain point).</span>
@@ -245,7 +249,8 @@ class VideoApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.upload_video_with_http_info(content_type, video_id, **kwargs)  # noqa: E501
         else:
@@ -263,6 +268,7 @@ class VideoApi(object):
 
         :param async_req bool
         :param str content_type: Use this header to specify the content type for the upload. The Content-Type should be set to <code>application/octet-stream</code>. (required)
+        :param dict files: Dictionary mapping field names to file paths. For example: {'file': 'path/to/video.mp4'}. The file will be read and sent as the request body for application/octet-stream uploads. (optional)  # ebay_rest patch: application/octet-stream file uploads
         :param str video_id: The unique identifier of the video to be uploaded. (required)
         :param InputStream body: The request payload for this method is the input stream for the video source. The input source must be an .mp4 file of the type MPEG-4 Part 10 or Advanced Video Coding (MPEG-4 AVC).
         :param str content_length: Use this header to specify the content length for the upload. Use Content-Range: bytes {1}-{2}/{3} and Content-Length:{4} headers.<br /><br /><span class=\"tablenote\"><span style=\"color:#004680\"><strong>Note:</strong></span> This header is optional and is only required for <i>resumable</i> uploads (when an upload is interrupted and must be resumed from a certain point).</span>
@@ -272,7 +278,7 @@ class VideoApi(object):
                  returns the request thread.
         """
 
-        all_params = ['content_type', 'video_id', 'body', 'content_length', 'content_range']  # noqa: E501
+        all_params = ['content_type', 'video_id', 'body', 'content_length', 'content_range', 'files']  # noqa: E501 - ebay_rest patch: application/octet-stream file uploads
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -316,8 +322,17 @@ class VideoApi(object):
         local_var_files = {}
 
         body_params = None
-        if 'body' in params:
-            body_params = params['body']
+        # ebay_rest patch: application/octet-stream file uploads
+        files = params.get('files')
+        if files:
+            # Read file from files dict and convert to body
+            file_path = next(iter(files.values()))
+            if os.path.isfile(file_path):
+                with open(file_path, 'rb') as f:
+                    body_params = f.read()
+        body = params.get('body')
+        if body:
+            body_params = body
         # HTTP header `Content-Type`
         header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
             ['application/octet-stream'])  # noqa: E501

--- a/src/ebay_rest/api/commerce_media/rest.py
+++ b/src/ebay_rest/api/commerce_media/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/commerce_notification/api/config_api.py
+++ b/src/ebay_rest/api/commerce_notification/api/config_api.py
@@ -46,7 +46,8 @@ class ConfigApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_config_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -135,7 +136,8 @@ class ConfigApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_config_with_http_info(content_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_notification/api/destination_api.py
+++ b/src/ebay_rest/api/commerce_notification/api/destination_api.py
@@ -48,7 +48,8 @@ class DestinationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_destination_with_http_info(content_type, **kwargs)  # noqa: E501
         else:
@@ -150,7 +151,8 @@ class DestinationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_destination_with_http_info(destination_id, **kwargs)  # noqa: E501
         else:
@@ -241,7 +243,8 @@ class DestinationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_destination_with_http_info(destination_id, **kwargs)  # noqa: E501
         else:
@@ -337,7 +340,8 @@ class DestinationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_destinations_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -433,7 +437,8 @@ class DestinationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_destination_with_http_info(content_type, destination_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_notification/api/public_key_api.py
+++ b/src/ebay_rest/api/commerce_notification/api/public_key_api.py
@@ -47,7 +47,8 @@ class PublicKeyApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_public_key_with_http_info(public_key_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_notification/api/subscription_api.py
+++ b/src/ebay_rest/api/commerce_notification/api/subscription_api.py
@@ -48,7 +48,8 @@ class SubscriptionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_subscription_with_http_info(content_type, **kwargs)  # noqa: E501
         else:
@@ -152,7 +153,8 @@ class SubscriptionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_subscription_filter_with_http_info(content_type, subscription_id, **kwargs)  # noqa: E501
         else:
@@ -261,7 +263,8 @@ class SubscriptionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_subscription_with_http_info(subscription_id, **kwargs)  # noqa: E501
         else:
@@ -353,7 +356,8 @@ class SubscriptionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_subscription_filter_with_http_info(filter_id, subscription_id, **kwargs)  # noqa: E501
         else:
@@ -451,7 +455,8 @@ class SubscriptionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.disable_subscription_with_http_info(subscription_id, **kwargs)  # noqa: E501
         else:
@@ -542,7 +547,8 @@ class SubscriptionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.enable_subscription_with_http_info(subscription_id, **kwargs)  # noqa: E501
         else:
@@ -633,7 +639,8 @@ class SubscriptionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_subscription_with_http_info(subscription_id, **kwargs)  # noqa: E501
         else:
@@ -729,7 +736,8 @@ class SubscriptionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_subscription_filter_with_http_info(filter_id, subscription_id, **kwargs)  # noqa: E501
         else:
@@ -832,7 +840,8 @@ class SubscriptionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_subscriptions_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -926,7 +935,8 @@ class SubscriptionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.test_subscription_with_http_info(subscription_id, **kwargs)  # noqa: E501
         else:
@@ -1019,7 +1029,8 @@ class SubscriptionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_subscription_with_http_info(content_type, subscription_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_notification/api/topic_api.py
+++ b/src/ebay_rest/api/commerce_notification/api/topic_api.py
@@ -47,7 +47,8 @@ class TopicApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_topic_with_http_info(topic_id, **kwargs)  # noqa: E501
         else:
@@ -143,7 +144,8 @@ class TopicApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_topics_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_notification/rest.py
+++ b/src/ebay_rest/api/commerce_notification/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/commerce_taxonomy/api/category_tree_api.py
+++ b/src/ebay_rest/api/commerce_taxonomy/api/category_tree_api.py
@@ -47,7 +47,8 @@ class CategoryTreeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.fetch_item_aspects_with_http_info(category_tree_id, **kwargs)  # noqa: E501
         else:
@@ -144,7 +145,8 @@ class CategoryTreeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_category_subtree_with_http_info(category_id, category_tree_id, **kwargs)  # noqa: E501
         else:
@@ -250,7 +252,8 @@ class CategoryTreeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_category_suggestions_with_http_info(category_tree_id, q, **kwargs)  # noqa: E501
         else:
@@ -353,7 +356,8 @@ class CategoryTreeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_category_tree_with_http_info(category_tree_id, **kwargs)  # noqa: E501
         else:
@@ -452,7 +456,8 @@ class CategoryTreeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_compatibility_properties_with_http_info(category_tree_id, category_id, **kwargs)  # noqa: E501
         else:
@@ -557,7 +562,8 @@ class CategoryTreeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_compatibility_property_values_with_http_info(category_tree_id, compatibility_property, category_id, **kwargs)  # noqa: E501
         else:
@@ -669,7 +675,8 @@ class CategoryTreeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_default_category_tree_id_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -764,7 +771,8 @@ class CategoryTreeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_expired_categories_with_http_info(category_tree_id, **kwargs)  # noqa: E501
         else:
@@ -860,7 +868,8 @@ class CategoryTreeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_item_aspects_for_category_with_http_info(category_id, category_tree_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_taxonomy/rest.py
+++ b/src/ebay_rest/api/commerce_taxonomy/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/commerce_translation/api/language_api.py
+++ b/src/ebay_rest/api/commerce_translation/api/language_api.py
@@ -48,7 +48,8 @@ class LanguageApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.translate_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/commerce_translation/rest.py
+++ b/src/ebay_rest/api/commerce_translation/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/developer_analytics/api/rate_limit_api.py
+++ b/src/ebay_rest/api/developer_analytics/api/rate_limit_api.py
@@ -48,7 +48,8 @@ class RateLimitApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_rate_limits_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/developer_analytics/api/user_rate_limit_api.py
+++ b/src/ebay_rest/api/developer_analytics/api/user_rate_limit_api.py
@@ -48,7 +48,8 @@ class UserRateLimitApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_user_rate_limits_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/developer_analytics/rest.py
+++ b/src/ebay_rest/api/developer_analytics/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/developer_client_registration/api/register_api.py
+++ b/src/ebay_rest/api/developer_client_registration/api/register_api.py
@@ -48,7 +48,8 @@ class RegisterApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.register_client_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/developer_client_registration/rest.py
+++ b/src/ebay_rest/api/developer_client_registration/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/developer_key_management/api/signing_key_api.py
+++ b/src/ebay_rest/api/developer_key_management/api/signing_key_api.py
@@ -48,7 +48,8 @@ class SigningKeyApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_signing_key_with_http_info(content_type, **kwargs)  # noqa: E501
         else:
@@ -150,7 +151,8 @@ class SigningKeyApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_signing_key_with_http_info(signing_key_id, **kwargs)  # noqa: E501
         else:
@@ -244,7 +246,8 @@ class SigningKeyApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_signing_keys_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/developer_key_management/rest.py
+++ b/src/ebay_rest/api/developer_key_management/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_account/api/payout_settings_api.py
+++ b/src/ebay_rest/api/sell_account/api/payout_settings_api.py
@@ -46,7 +46,8 @@ class PayoutSettingsApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_payout_settings_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -135,7 +136,8 @@ class PayoutSettingsApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_payout_percentage_with_http_info(content_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_account/api/rate_table_api.py
+++ b/src/ebay_rest/api/sell_account/api/rate_table_api.py
@@ -47,7 +47,8 @@ class RateTableApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_rate_table_with_http_info(rate_table_id, **kwargs)  # noqa: E501
         else:
@@ -144,7 +145,8 @@ class RateTableApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_shipping_cost_with_http_info(content_type, rate_table_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_account/rest.py
+++ b/src/ebay_rest/api/sell_account/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_analytics/api/customer_service_metric_api.py
+++ b/src/ebay_rest/api/sell_analytics/api/customer_service_metric_api.py
@@ -49,7 +49,8 @@ class CustomerServiceMetricApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_customer_service_metric_with_http_info(customer_service_metric_type, evaluation_marketplace_id, evaluation_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_analytics/api/seller_standards_profile_api.py
+++ b/src/ebay_rest/api/sell_analytics/api/seller_standards_profile_api.py
@@ -46,7 +46,8 @@ class SellerStandardsProfileApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.find_seller_standards_profiles_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -135,7 +136,8 @@ class SellerStandardsProfileApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_seller_standards_profile_with_http_info(cycle, program, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_analytics/api/traffic_report_api.py
+++ b/src/ebay_rest/api/sell_analytics/api/traffic_report_api.py
@@ -50,7 +50,8 @@ class TrafficReportApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_traffic_report_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_analytics/rest.py
+++ b/src/ebay_rest/api/sell_analytics/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_compliance/api/listing_violation_api.py
+++ b/src/ebay_rest/api/sell_compliance/api/listing_violation_api.py
@@ -52,7 +52,8 @@ class ListingViolationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_listing_violations_with_http_info(x_ebay_c_marketplace_id, compliance_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_compliance/api/listing_violation_summary_api.py
+++ b/src/ebay_rest/api/sell_compliance/api/listing_violation_summary_api.py
@@ -48,7 +48,8 @@ class ListingViolationSummaryApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_listing_violations_summary_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_compliance/rest.py
+++ b/src/ebay_rest/api/sell_compliance/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_feed/api/customer_service_metric_task_api.py
+++ b/src/ebay_rest/api/sell_feed/api/customer_service_metric_task_api.py
@@ -49,7 +49,8 @@ class CustomerServiceMetricTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_customer_service_metric_task_with_http_info(body, accept_language, content_type, **kwargs)  # noqa: E501
         else:
@@ -158,7 +159,8 @@ class CustomerServiceMetricTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_customer_service_metric_task_with_http_info(task_id, **kwargs)  # noqa: E501
         else:
@@ -257,7 +259,8 @@ class CustomerServiceMetricTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_customer_service_metric_tasks_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_feed/api/inventory_task_api.py
+++ b/src/ebay_rest/api/sell_feed/api/inventory_task_api.py
@@ -48,7 +48,8 @@ class InventoryTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_inventory_task_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -150,7 +151,8 @@ class InventoryTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_inventory_task_with_http_info(task_id, **kwargs)  # noqa: E501
         else:
@@ -250,7 +252,8 @@ class InventoryTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_inventory_tasks_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_feed/api/order_task_api.py
+++ b/src/ebay_rest/api/sell_feed/api/order_task_api.py
@@ -48,7 +48,8 @@ class OrderTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_order_task_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -150,7 +151,8 @@ class OrderTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_order_task_with_http_info(task_id, **kwargs)  # noqa: E501
         else:
@@ -250,7 +252,8 @@ class OrderTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_order_tasks_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_feed/api/schedule_api.py
+++ b/src/ebay_rest/api/sell_feed/api/schedule_api.py
@@ -48,7 +48,8 @@ class ScheduleApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_schedule_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -154,7 +155,8 @@ class ScheduleApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_schedule_with_http_info(schedule_id, **kwargs)  # noqa: E501
         else:
@@ -245,7 +247,8 @@ class ScheduleApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_latest_result_file_with_http_info(schedule_id, **kwargs)  # noqa: E501
         else:
@@ -340,7 +343,8 @@ class ScheduleApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_schedule_with_http_info(schedule_id, **kwargs)  # noqa: E501
         else:
@@ -435,7 +439,8 @@ class ScheduleApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_schedule_template_with_http_info(schedule_template_id, **kwargs)  # noqa: E501
         else:
@@ -532,7 +537,8 @@ class ScheduleApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_schedule_templates_with_http_info(feed_type, **kwargs)  # noqa: E501
         else:
@@ -635,7 +641,8 @@ class ScheduleApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_schedules_with_http_info(feed_type, **kwargs)  # noqa: E501
         else:
@@ -738,7 +745,8 @@ class ScheduleApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_schedule_with_http_info(body, content_type, schedule_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_feed/api/task_api.py
+++ b/src/ebay_rest/api/sell_feed/api/task_api.py
@@ -50,7 +50,8 @@ class TaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_task_with_http_info(body, x_ebay_c_marketplace_id, content_type, **kwargs)  # noqa: E501
         else:
@@ -162,7 +163,8 @@ class TaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_input_file_with_http_info(task_id, **kwargs)  # noqa: E501
         else:
@@ -257,7 +259,8 @@ class TaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_result_file_with_http_info(task_id, **kwargs)  # noqa: E501
         else:
@@ -352,7 +355,8 @@ class TaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_task_with_http_info(task_id, **kwargs)  # noqa: E501
         else:
@@ -452,7 +456,8 @@ class TaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_tasks_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -560,7 +565,8 @@ class TaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.upload_file_with_http_info(task_id, content_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_feed/rest.py
+++ b/src/ebay_rest/api/sell_feed/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_finances/api/payout_api.py
+++ b/src/ebay_rest/api/sell_finances/api/payout_api.py
@@ -48,7 +48,8 @@ class PayoutApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_payout_with_http_info(x_ebay_c_marketplace_id, payout_id, **kwargs)  # noqa: E501
         else:
@@ -151,7 +152,8 @@ class PayoutApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_payout_summary_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -253,7 +255,8 @@ class PayoutApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_payouts_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_finances/api/seller_funds_summary_api.py
+++ b/src/ebay_rest/api/sell_finances/api/seller_funds_summary_api.py
@@ -47,7 +47,8 @@ class SellerFundsSummaryApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_seller_funds_summary_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_finances/api/transaction_api.py
+++ b/src/ebay_rest/api/sell_finances/api/transaction_api.py
@@ -48,7 +48,8 @@ class TransactionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_transaction_summary_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -150,7 +151,8 @@ class TransactionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_transactions_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_finances/api/transfer_api.py
+++ b/src/ebay_rest/api/sell_finances/api/transfer_api.py
@@ -48,7 +48,8 @@ class TransferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_transfer_with_http_info(x_ebay_c_marketplace_id, transfer_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_finances/rest.py
+++ b/src/ebay_rest/api/sell_finances/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_fulfillment/api/order_api.py
+++ b/src/ebay_rest/api/sell_fulfillment/api/order_api.py
@@ -48,7 +48,8 @@ class OrderApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_order_with_http_info(order_id, **kwargs)  # noqa: E501
         else:
@@ -150,7 +151,8 @@ class OrderApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_orders_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -255,7 +257,8 @@ class OrderApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.issue_refund_with_http_info(content_type, order_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_fulfillment/api/payment_dispute_api.py
+++ b/src/ebay_rest/api/sell_fulfillment/api/payment_dispute_api.py
@@ -49,7 +49,8 @@ class PaymentDisputeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.accept_payment_dispute_with_http_info(content_type, payment_dispute_id, **kwargs)  # noqa: E501
         else:
@@ -156,7 +157,8 @@ class PaymentDisputeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.add_evidence_with_http_info(content_type, payment_dispute_id, **kwargs)  # noqa: E501
         else:
@@ -267,7 +269,8 @@ class PaymentDisputeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.contest_payment_dispute_with_http_info(content_type, payment_dispute_id, **kwargs)  # noqa: E501
         else:
@@ -374,7 +377,8 @@ class PaymentDisputeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.fetch_evidence_content_with_http_info(payment_dispute_id, evidence_id, file_id, **kwargs)  # noqa: E501
         else:
@@ -483,7 +487,8 @@ class PaymentDisputeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_activities_with_http_info(payment_dispute_id, **kwargs)  # noqa: E501
         else:
@@ -578,7 +583,8 @@ class PaymentDisputeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_payment_dispute_with_http_info(payment_dispute_id, **kwargs)  # noqa: E501
         else:
@@ -679,7 +685,8 @@ class PaymentDisputeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_payment_dispute_summaries_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -790,7 +797,8 @@ class PaymentDisputeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_evidence_with_http_info(content_type, payment_dispute_id, **kwargs)  # noqa: E501
         else:
@@ -897,7 +905,8 @@ class PaymentDisputeApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.upload_evidence_file_with_http_info(payment_dispute_id, content_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_fulfillment/api/shipping_fulfillment_api.py
+++ b/src/ebay_rest/api/sell_fulfillment/api/shipping_fulfillment_api.py
@@ -49,7 +49,8 @@ class ShippingFulfillmentApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_shipping_fulfillment_with_http_info(body, content_type, order_id, **kwargs)  # noqa: E501
         else:
@@ -163,7 +164,8 @@ class ShippingFulfillmentApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_shipping_fulfillment_with_http_info(fulfillment_id, order_id, **kwargs)  # noqa: E501
         else:
@@ -265,7 +267,8 @@ class ShippingFulfillmentApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_shipping_fulfillments_with_http_info(order_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_fulfillment/rest.py
+++ b/src/ebay_rest/api/sell_fulfillment/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_inventory/api/inventory_item_api.py
+++ b/src/ebay_rest/api/sell_inventory/api/inventory_item_api.py
@@ -49,7 +49,8 @@ class InventoryItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_create_or_replace_inventory_item_with_http_info(body, content_type, content_language, **kwargs)  # noqa: E501
         else:
@@ -163,7 +164,8 @@ class InventoryItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_get_inventory_item_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -270,7 +272,8 @@ class InventoryItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_update_price_quantity_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -379,7 +382,8 @@ class InventoryItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_or_replace_inventory_item_with_http_info(body, content_language, content_type, sku, **kwargs)  # noqa: E501
         else:
@@ -499,7 +503,8 @@ class InventoryItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_inventory_item_with_http_info(sku, **kwargs)  # noqa: E501
         else:
@@ -590,7 +595,8 @@ class InventoryItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_inventory_item_with_http_info(sku, **kwargs)  # noqa: E501
         else:
@@ -686,7 +692,8 @@ class InventoryItemApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_inventory_items_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_inventory/api/inventory_item_group_api.py
+++ b/src/ebay_rest/api/sell_inventory/api/inventory_item_group_api.py
@@ -50,7 +50,8 @@ class InventoryItemGroupApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_or_replace_inventory_item_group_with_http_info(body, content_language, content_type, inventory_item_group_key, **kwargs)  # noqa: E501
         else:
@@ -170,7 +171,8 @@ class InventoryItemGroupApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_inventory_item_group_with_http_info(inventory_item_group_key, **kwargs)  # noqa: E501
         else:
@@ -261,7 +263,8 @@ class InventoryItemGroupApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_inventory_item_group_with_http_info(inventory_item_group_key, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_inventory/api/listing_api.py
+++ b/src/ebay_rest/api/sell_inventory/api/listing_api.py
@@ -48,7 +48,8 @@ class ListingApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_migrate_listing_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -157,7 +158,8 @@ class ListingApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_or_replace_sku_location_mapping_with_http_info(body, content_type, listing_id, sku, **kwargs)  # noqa: E501
         else:
@@ -274,7 +276,8 @@ class ListingApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_sku_location_mapping_with_http_info(listing_id, sku, **kwargs)  # noqa: E501
         else:
@@ -373,7 +376,8 @@ class ListingApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_sku_location_mapping_with_http_info(listing_id, sku, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_inventory/api/location_api.py
+++ b/src/ebay_rest/api/sell_inventory/api/location_api.py
@@ -49,7 +49,8 @@ class LocationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_inventory_location_with_http_info(body, content_type, merchant_location_key, **kwargs)  # noqa: E501
         else:
@@ -158,7 +159,8 @@ class LocationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_inventory_location_with_http_info(merchant_location_key, **kwargs)  # noqa: E501
         else:
@@ -249,7 +251,8 @@ class LocationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.disable_inventory_location_with_http_info(merchant_location_key, **kwargs)  # noqa: E501
         else:
@@ -344,7 +347,8 @@ class LocationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.enable_inventory_location_with_http_info(merchant_location_key, **kwargs)  # noqa: E501
         else:
@@ -439,7 +443,8 @@ class LocationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_inventory_location_with_http_info(merchant_location_key, **kwargs)  # noqa: E501
         else:
@@ -535,7 +540,8 @@ class LocationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_inventory_locations_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -631,7 +637,8 @@ class LocationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_inventory_location_with_http_info(body, content_type, merchant_location_key, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_inventory/api/offer_api.py
+++ b/src/ebay_rest/api/sell_inventory/api/offer_api.py
@@ -49,7 +49,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_create_offer_with_http_info(body, content_language, content_type, **kwargs)  # noqa: E501
         else:
@@ -163,7 +164,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_publish_offer_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -271,7 +273,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_offer_with_http_info(body, content_language, content_type, **kwargs)  # noqa: E501
         else:
@@ -384,7 +387,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_offer_with_http_info(offer_id, **kwargs)  # noqa: E501
         else:
@@ -476,7 +480,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_listing_fees_with_http_info(content_type, **kwargs)  # noqa: E501
         else:
@@ -578,7 +583,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_offer_with_http_info(offer_id, **kwargs)  # noqa: E501
         else:
@@ -677,7 +683,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_offers_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -780,7 +787,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.publish_offer_with_http_info(offer_id, **kwargs)  # noqa: E501
         else:
@@ -876,7 +884,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.publish_offer_by_inventory_item_group_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -985,7 +994,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_offer_with_http_info(body, content_language, content_type, offer_id, **kwargs)  # noqa: E501
         else:
@@ -1105,7 +1115,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.withdraw_offer_with_http_info(offer_id, **kwargs)  # noqa: E501
         else:
@@ -1201,7 +1212,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.withdraw_offer_by_inventory_item_group_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_inventory/api/product_compatibility_api.py
+++ b/src/ebay_rest/api/sell_inventory/api/product_compatibility_api.py
@@ -50,7 +50,8 @@ class ProductCompatibilityApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_or_replace_product_compatibility_with_http_info(body, content_language, content_type, sku, **kwargs)  # noqa: E501
         else:
@@ -170,7 +171,8 @@ class ProductCompatibilityApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_product_compatibility_with_http_info(sku, **kwargs)  # noqa: E501
         else:
@@ -261,7 +263,8 @@ class ProductCompatibilityApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_product_compatibility_with_http_info(sku, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_inventory/rest.py
+++ b/src/ebay_rest/api/sell_inventory/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_logistics/api/shipment_api.py
+++ b/src/ebay_rest/api/sell_logistics/api/shipment_api.py
@@ -47,7 +47,8 @@ class ShipmentApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.cancel_shipment_with_http_info(shipment_id, **kwargs)  # noqa: E501
         else:
@@ -144,7 +145,8 @@ class ShipmentApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_from_shipping_quote_with_http_info(body, content_type, x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -258,7 +260,8 @@ class ShipmentApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.download_label_file_with_http_info(shipment_id, accept, **kwargs)  # noqa: E501
         else:
@@ -360,7 +363,8 @@ class ShipmentApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_shipment_with_http_info(shipment_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_logistics/api/shipping_quote_api.py
+++ b/src/ebay_rest/api/sell_logistics/api/shipping_quote_api.py
@@ -49,7 +49,8 @@ class ShippingQuoteApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_shipping_quote_with_http_info(body, x_ebay_c_marketplace_id, content_type, **kwargs)  # noqa: E501
         else:
@@ -162,7 +163,8 @@ class ShippingQuoteApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_shipping_quote_with_http_info(shipping_quote_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_logistics/rest.py
+++ b/src/ebay_rest/api/sell_logistics/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_marketing/api/ad_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/ad_api.py
@@ -49,7 +49,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_create_ads_by_inventory_reference_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -164,7 +165,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_create_ads_by_listing_id_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -279,7 +281,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_delete_ads_by_inventory_reference_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -394,7 +397,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_delete_ads_by_listing_id_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -509,7 +513,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_update_ads_bid_by_inventory_reference_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -624,7 +629,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_update_ads_bid_by_listing_id_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -739,7 +745,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_update_ads_status_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -854,7 +861,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_update_ads_status_by_listing_id_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -969,7 +977,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_ad_by_listing_id_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1084,7 +1093,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_ads_by_inventory_reference_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1198,7 +1208,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_ad_with_http_info(ad_id, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1298,7 +1309,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_ads_by_inventory_reference_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1412,7 +1424,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_ad_with_http_info(ad_id, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1519,7 +1532,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_ads_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1631,7 +1645,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_ads_by_inventory_reference_with_http_info(campaign_id, inventory_reference_id, inventory_reference_type, **kwargs)  # noqa: E501
         else:
@@ -1743,7 +1758,8 @@ class AdApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_bid_with_http_info(body, content_type, ad_id, campaign_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/ad_group_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/ad_group_api.py
@@ -49,7 +49,8 @@ class AdGroupApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_ad_group_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -163,7 +164,8 @@ class AdGroupApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_ad_group_with_http_info(ad_group_id, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -268,7 +270,8 @@ class AdGroupApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_ad_groups_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
@@ -375,7 +378,8 @@ class AdGroupApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.suggest_bids_with_http_info(body, content_type, ad_group_id, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -498,7 +502,8 @@ class AdGroupApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.suggest_keywords_with_http_info(content_type, ad_group_id, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -617,7 +622,8 @@ class AdGroupApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_ad_group_with_http_info(body, content_type, ad_group_id, campaign_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/ad_report_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/ad_report_api.py
@@ -47,7 +47,8 @@ class AdReportApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_report_with_http_info(report_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/ad_report_metadata_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/ad_report_metadata_api.py
@@ -48,7 +48,8 @@ class AdReportMetadataApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_report_metadata_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -144,7 +145,8 @@ class AdReportMetadataApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_report_metadata_for_report_type_with_http_info(report_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/ad_report_task_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/ad_report_task_api.py
@@ -48,7 +48,8 @@ class AdReportTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_report_task_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -150,7 +151,8 @@ class AdReportTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_report_task_with_http_info(report_task_id, **kwargs)  # noqa: E501
         else:
@@ -241,7 +243,8 @@ class AdReportTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_report_task_with_http_info(report_task_id, **kwargs)  # noqa: E501
         else:
@@ -338,7 +341,8 @@ class AdReportTaskApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_report_tasks_with_http_info(**kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/campaign_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/campaign_api.py
@@ -49,7 +49,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.clone_campaign_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -163,7 +164,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_campaign_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -269,7 +271,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
@@ -360,7 +363,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.end_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
@@ -453,7 +457,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.find_campaign_by_ad_reference_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -550,7 +555,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
@@ -645,7 +651,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_campaign_by_name_with_http_info(campaign_name, **kwargs)  # noqa: E501
         else:
@@ -748,7 +755,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_campaigns_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -863,7 +871,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.launch_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
@@ -954,7 +963,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.pause_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1045,7 +1055,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.resume_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1137,7 +1148,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.setup_quick_campaign_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -1243,7 +1255,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.suggest_budget_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -1341,7 +1354,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.suggest_items_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1446,7 +1460,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.suggest_max_cpc_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -1554,7 +1569,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_ad_rate_strategy_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1665,7 +1681,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_bidding_strategy_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1776,7 +1793,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_campaign_budget_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -1891,7 +1909,8 @@ class CampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_campaign_identification_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/email_campaign_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/email_campaign_api.py
@@ -49,7 +49,8 @@ class EmailCampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_email_campaign_with_http_info(body, x_ebay_c_marketplace_id, content_type, **kwargs)  # noqa: E501
         else:
@@ -162,7 +163,8 @@ class EmailCampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_email_campaign_with_http_info(email_campaign_id, **kwargs)  # noqa: E501
         else:
@@ -259,7 +261,8 @@ class EmailCampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_audiences_with_http_info(email_campaign_type, **kwargs)  # noqa: E501
         else:
@@ -360,7 +363,8 @@ class EmailCampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_email_campaign_with_http_info(email_campaign_id, **kwargs)  # noqa: E501
         else:
@@ -458,7 +462,8 @@ class EmailCampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_email_campaigns_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -558,7 +563,8 @@ class EmailCampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_email_preview_with_http_info(email_campaign_id, **kwargs)  # noqa: E501
         else:
@@ -654,7 +660,8 @@ class EmailCampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_email_report_with_http_info(end_date, start_date, **kwargs)  # noqa: E501
         else:
@@ -758,7 +765,8 @@ class EmailCampaignApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_email_campaign_with_http_info(body, content_type, email_campaign_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/item_price_markdown_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/item_price_markdown_api.py
@@ -48,7 +48,8 @@ class ItemPriceMarkdownApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_item_price_markdown_promotion_with_http_info(content_type, **kwargs)  # noqa: E501
         else:
@@ -150,7 +151,8 @@ class ItemPriceMarkdownApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_item_price_markdown_promotion_with_http_info(promotion_id, **kwargs)  # noqa: E501
         else:
@@ -241,7 +243,8 @@ class ItemPriceMarkdownApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_item_price_markdown_promotion_with_http_info(promotion_id, **kwargs)  # noqa: E501
         else:
@@ -338,7 +341,8 @@ class ItemPriceMarkdownApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_item_price_markdown_promotion_with_http_info(content_type, promotion_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/item_promotion_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/item_promotion_api.py
@@ -48,7 +48,8 @@ class ItemPromotionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_item_promotion_with_http_info(content_type, **kwargs)  # noqa: E501
         else:
@@ -150,7 +151,8 @@ class ItemPromotionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.delete_item_promotion_with_http_info(promotion_id, **kwargs)  # noqa: E501
         else:
@@ -241,7 +243,8 @@ class ItemPromotionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_item_promotion_with_http_info(promotion_id, **kwargs)  # noqa: E501
         else:
@@ -338,7 +341,8 @@ class ItemPromotionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_item_promotion_with_http_info(content_type, promotion_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/keyword_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/keyword_api.py
@@ -49,7 +49,8 @@ class KeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_create_keyword_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -164,7 +165,8 @@ class KeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_update_keyword_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -279,7 +281,8 @@ class KeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_keyword_with_http_info(body, content_type, campaign_id, **kwargs)  # noqa: E501
         else:
@@ -393,7 +396,8 @@ class KeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_keyword_with_http_info(campaign_id, keyword_id, **kwargs)  # noqa: E501
         else:
@@ -499,7 +503,8 @@ class KeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_keywords_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
@@ -609,7 +614,8 @@ class KeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_keyword_with_http_info(body, content_type, campaign_id, keyword_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/negative_keyword_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/negative_keyword_api.py
@@ -48,7 +48,8 @@ class NegativeKeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_create_negative_keyword_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -155,7 +156,8 @@ class NegativeKeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.bulk_update_negative_keyword_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -262,7 +264,8 @@ class NegativeKeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.create_negative_keyword_with_http_info(body, content_type, **kwargs)  # noqa: E501
         else:
@@ -368,7 +371,8 @@ class NegativeKeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_negative_keyword_with_http_info(negative_keyword_id, **kwargs)  # noqa: E501
         else:
@@ -467,7 +471,8 @@ class NegativeKeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_negative_keywords_with_http_info(**kwargs)  # noqa: E501
         else:
@@ -572,7 +577,8 @@ class NegativeKeywordApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.update_negative_keyword_with_http_info(body, content_type, negative_keyword_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/promotion_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/promotion_api.py
@@ -52,7 +52,8 @@ class PromotionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_listing_set_with_http_info(promotion_id, **kwargs)  # noqa: E501
         else:
@@ -168,7 +169,8 @@ class PromotionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_promotions_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -281,7 +283,8 @@ class PromotionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.pause_promotion_with_http_info(promotion_id, **kwargs)  # noqa: E501
         else:
@@ -372,7 +375,8 @@ class PromotionApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.resume_promotion_with_http_info(promotion_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/promotion_report_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/promotion_report_api.py
@@ -52,7 +52,8 @@ class PromotionReportApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_promotion_reports_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/api/promotion_summary_report_api.py
+++ b/src/ebay_rest/api/sell_marketing/api/promotion_summary_report_api.py
@@ -47,7 +47,8 @@ class PromotionSummaryReportApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_promotion_summary_report_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_marketing/rest.py
+++ b/src/ebay_rest/api/sell_marketing/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_metadata/api/compatibilities_api.py
+++ b/src/ebay_rest/api/sell_metadata/api/compatibilities_api.py
@@ -49,7 +49,8 @@ class CompatibilitiesApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_compatibilities_by_specification_with_http_info(x_ebay_c_marketplace_id, content_type, **kwargs)  # noqa: E501
         else:
@@ -160,7 +161,8 @@ class CompatibilitiesApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_compatibility_property_names_with_http_info(x_ebay_c_marketplace_id, content_type, **kwargs)  # noqa: E501
         else:
@@ -271,7 +273,8 @@ class CompatibilitiesApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_compatibility_property_values_with_http_info(x_ebay_c_marketplace_id, content_type, **kwargs)  # noqa: E501
         else:
@@ -382,7 +385,8 @@ class CompatibilitiesApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_multi_compatibility_property_values_with_http_info(x_ebay_c_marketplace_id, content_type, **kwargs)  # noqa: E501
         else:
@@ -493,7 +497,8 @@ class CompatibilitiesApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_product_compatibilities_with_http_info(x_ebay_c_marketplace_id, content_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_metadata/api/country_api.py
+++ b/src/ebay_rest/api/sell_metadata/api/country_api.py
@@ -47,7 +47,8 @@ class CountryApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_sales_tax_jurisdictions_with_http_info(country_code, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_metadata/api/marketplace_api.py
+++ b/src/ebay_rest/api/sell_metadata/api/marketplace_api.py
@@ -49,7 +49,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_automotive_parts_compatibility_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -152,7 +153,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_category_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -255,7 +257,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_classified_ad_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -357,7 +360,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_currencies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -458,7 +462,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_extended_producer_responsibility_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -563,7 +568,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_hazardous_materials_labels_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -664,7 +670,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_item_condition_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -771,7 +778,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_listing_structure_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -877,7 +885,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_listing_type_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -980,7 +989,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_motors_listing_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -1084,7 +1094,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_negotiated_price_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -1188,7 +1199,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_product_safety_labels_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -1285,7 +1297,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_regulatory_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -1389,7 +1402,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_return_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -1495,7 +1509,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_shipping_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -1598,7 +1613,8 @@ class MarketplaceApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.get_site_visibility_policies_with_http_info(marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_metadata/rest.py
+++ b/src/ebay_rest/api/sell_metadata/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_negotiation/api/offer_api.py
+++ b/src/ebay_rest/api/sell_negotiation/api/offer_api.py
@@ -49,7 +49,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.find_eligible_items_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:
@@ -152,7 +153,8 @@ class OfferApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.send_offer_to_interested_buyers_with_http_info(x_ebay_c_marketplace_id, content_type, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_negotiation/rest.py
+++ b/src/ebay_rest/api/sell_negotiation/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided

--- a/src/ebay_rest/api/sell_recommendation/api/listing_recommendation_api.py
+++ b/src/ebay_rest/api/sell_recommendation/api/listing_recommendation_api.py
@@ -51,7 +51,8 @@ class ListingRecommendationApi(object):
                  If the method is called asynchronously,
                  returns the request thread.
         """
-        kwargs['_return_http_data_only'] = True
+        if '_return_http_data_only' not in kwargs:  # ebay_rest patch
+            kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
             return self.find_listing_recommendations_with_http_info(x_ebay_c_marketplace_id, **kwargs)  # noqa: E501
         else:

--- a/src/ebay_rest/api/sell_recommendation/rest.py
+++ b/src/ebay_rest/api/sell_recommendation/rest.py
@@ -197,6 +197,14 @@ class RESTClientObject(object):
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
+                # ebay_rest patch: Handle bytes body for application/octet-stream
+                elif isinstance(body, bytes):
+                    r = signed_request(self.pool_manager, self.key_pair,  # ebay_rest patch
+                        method, url,
+                        body=body,
+                        preload_content=_preload_content,
+                        timeout=timeout,
+                        headers=headers)
                 else:
                     # Cannot generate the request from given parameters
                     msg = """Cannot prepare a request message for provided


### PR DESCRIPTION
Resolves #60 & Resolves #38 (every method that uploads a file has now been patched & new patches allow you to access response headers)
## Summary
Developed and applied multiple patches to allow upload_video to work and fixed its unit_test.

### Details
- Patched methods that use `application/octet-stream` (upload_video) to read file from dictionary - example:
```
commerce_media_upload_video(
                content_type="application/octet-stream",
                video_id="video_id",
                files={"file": "/path/to/video.mp4"})
```
- Patched `rest.py` to support bytes upload for `application/octet-stream`
- Patched all wrapper methods to only set `_return_http_data_only=True` if not already in kwargs. This allows users to pass `_return_http_data_only=False` to get headers and is used in the unit test to extract the `Location` header
    - This is needed because eBay's API is inconsistent:
        - Documents: document_id is in both the response body and the Location header
        - Videos: video_id is only in the Location header
- Fixed `test_commerce_media_upload_video` to get video ID from header, upload video, and get info to verify upload
- Moved `test_commerce_media_upload_video` to `APISandboxSingleSiteTests` since it works in the sandbox
- Fixed simple TypeError in `_de_swagger`