### PR TITLE
Refactor OAuth2 logic to use Authlib and cleanup obsolete code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Natural Language :: English",
     "Topic :: Internet"
 ]
-dependencies = ["certifi", "cryptography", "requests", "python-dateutil", "six", "urllib3"]
+dependencies = ["authlib", "certifi", "cryptography", "requests", "python-dateutil", "six", "urllib3"]
 
 [project.urls]
 Homepage = "https://github.com/matecsaj/ebay_rest"


### PR DESCRIPTION
Hi! I've refactored the token.py file to modernize how eBay's OAuth2 flows are handled. Instead of manually constructing HTTP requests, headers, and bodies, the project now uses the Authlib library.

Main changes:
I replaced the manual request logic with OAuth2Session. It handles the heavy lifting, including header management and token fetching. I also created a central _finish method to process token responses, which allowed me to delete about 100 lines of obsolete helper methods that were cluttering the class.

The pyproject.toml is updated with the new dependency, __slots__ now includes the session, and unused imports like json and time have been removed.

Testing:
I ran manual tests on Python 3.14 to confirm that the _OAuth2Api class initializes correctly and the Authlib session is ready to go.

Closes #104

P.S. This is my first contribution here, so if you need any adjustments or if I missed any project standards, just let me know. I'm happy to help!